### PR TITLE
Align NBA API dependency automation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ COPY migrations migrations
 RUN pip install -r requirements.txt
 
 EXPOSE 5000
-CMD ["uvicorn", "unicorn:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["sh", "-c", "flask --app manage:app db upgrade && exec uvicorn unicorn:app --host 0.0.0.0 --port 5000"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The service uses:
     - templates
     - views
   - test
-- Includes test framework (`py.test`)
+- Includes a pytest test suite
 - Includes database migration framework (`alembic`)
 
 ## Installation
@@ -48,7 +48,10 @@ For Docker Compose, create the local environment file first:
 
 ### Initializing the Database
 
-    # Create DB tables and populate sample people
+    # Apply the checked-in schema migrations
+    flask --app manage:app db upgrade
+
+    # For local demos only: reset the database and populate sample people
     flask --app manage init-db
 
 ### 3. Run the application
@@ -59,17 +62,21 @@ For local development:
 
 #### Running the app (production)
 
-The container runs the Connexion ASGI application with Uvicorn:
+The container applies the checked-in Alembic migrations, then runs the
+Connexion ASGI application with Uvicorn. Set `DATABASE_URL` to a persistent
+database for deployed use.
 
     docker compose up --build
 
 #### Running the automated tests
 
-    pytest -q
+    python -m pytest -q
 
 ### Updating dependencies
 
-Edit the direct pins in `requirements.in`, then regenerate the complete lock file with Python 3.14:
+Edit the direct pins in `requirements.in`, then regenerate the complete lock
+file with Python 3.14. Renovate is configured to use the same `pip-compile`
+contract and will not update transitive pins independently.
 
     python -m pip install pip-tools
     pip-compile --upgrade --resolver=backtracking --strip-extras --output-file=requirements.txt requirements.in

--- a/migrations/versions/3f45a7d8b2c1_create_person_table.py
+++ b/migrations/versions/3f45a7d8b2c1_create_person_table.py
@@ -1,0 +1,28 @@
+"""Create the initial person table.
+
+Revision ID: 3f45a7d8b2c1
+Revises:
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "3f45a7d8b2c1"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "person",
+        sa.Column("person_id", sa.Integer(), nullable=False),
+        sa.Column("lname", sa.String(length=32), nullable=True),
+        sa.Column("fname", sa.String(length=32), nullable=True),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("person_id"),
+    )
+
+
+def downgrade():
+    op.drop_table("person")

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,17 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ]
+    "config:recommended"
+  ],
+  "constraints": {
+    "python": "==3.14"
+  },
+  "pip-compile": {
+    "managerFilePatterns": [
+      "/(^|/)requirements\\.txt$/"
+    ]
+  },
+  "pip_requirements": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Summary

- configure Renovate to manage `requirements.txt` as a Python 3.14 `pip-compile` lock derived from `requirements.in`
- disable the overlapping generic requirements manager so transitive pins are not updated independently
- migrate Renovate from `config:base` to `config:recommended`
- add the missing initial Alembic revision and apply migrations before Uvicorn starts
- document the dependency, migration, container, and test contracts

## Why

PR #113 attempts to update `pydantic-core` from 2.46.4 to 2.47.0 without updating Pydantic. Current Pydantic 2.13.4 requires `pydantic-core==2.46.4`, so the proposed lock is inconsistent and cannot install. `pydantic-core` is transitive and should be resolved by `pip-compile`, not edited independently.

During live validation, the container's landing page returned 200 but `/api/people` returned 500 because no checked-in migration created the `person` table. This PR fixes that startup contract as well.

## Validation

- official `renovate/renovate:latest` config validator: passed without migration warnings
- Python 3.14 `pip-compile` regeneration: byte-for-byte identical lock
- Docker image build: passed
- `python -m pytest -q`: 2 passed
- `pip-audit -r requirements.txt`: no known vulnerabilities
- Alembic upgrade -> downgrade -> upgrade: passed; head `3f45a7d8b2c1`
- live Uvicorn container: `/` HTTP 200 and `/api/people` HTTP 200 with `[]`

## Scope and release boundary

This changes only dependency automation and the NBA API's existing database/container startup contract. It does not deploy the service or seed production data. The `init-db` command remains explicitly destructive and is documented for local demos only.

## Rollback

Revert this commit and run `flask --app manage:app db downgrade base` only if the newly created `person` table must be removed. Do not downgrade a database containing data without a backup.

## Review focus

- Renovate manager separation and Python constraint
- the initial reversible schema revision
- startup migration ordering before Uvicorn
