### PR TITLE
Remove the unused Celery runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,10 +94,6 @@ ipython_config.py
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/
 
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
 # SageMath parsed files
 *.sage.py
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ client
 - `migrations/` owns the Alembic schema history.
 - `unicorn.py` exposes the Connexion ASGI application consumed by Uvicorn.
 - `manage.py` exposes the underlying Flask application for CLI and migration commands.
-- `app/celery/` is an unintegrated worker scaffold; Compose does not currently run a broker or
-  worker.
+
+The production runtime is request-driven and intentionally has no background worker or message
+broker. Add asynchronous processing only with a concrete job contract, idempotency and retry rules,
+broker ownership, observability, and corresponding Compose and CI coverage; do not ship an
+unexercised worker dependency in the API image.
 
 ## Requirements
 

--- a/app/celery/celery_app.py
+++ b/app/celery/celery_app.py
@@ -1,5 +1,0 @@
-from celery import Celery
-
-celery_app = Celery("worker", broker="amqp://guest@queue//")
-
-celery_app.conf.task_routes = {"app.worker.test_celery": "main-queue"}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,6 @@ a2wsgi==1.10.10
     # via connexion
 alembic==1.19.0
     # via flask-migrate
-amqp==5.3.1
-    # via kombu
 annotated-types==0.8.0
     # via pydantic
 anyio==4.14.2
@@ -22,16 +20,12 @@ attrs==26.1.0
     #   jsonschema
     #   jsonschema-path
     #   referencing
-billiard==4.2.4
-    # via celery
 blinker==1.9.0
     # via flask
 boolean-py==5.0
     # via license-expression
 cachecontrol==0.14.4
     # via pip-audit
-celery==5.6.3
-    # via -r requirements.in
 certifi==2026.7.22
     # via
     #   httpcore
@@ -41,18 +35,8 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via
-    #   celery
-    #   click-didyoumean
-    #   click-plugins
-    #   click-repl
     #   flask
     #   uvicorn
-click-didyoumean==0.3.1
-    # via celery
-click-plugins==1.1.1.2
-    # via celery
-click-repl==0.3.0
-    # via celery
 connexion==3.3.0
     # via -r requirements.in
 coverage==7.15.4
@@ -126,8 +110,6 @@ jsonschema-specifications==2025.9.1
     # via
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.6.2
-    # via celery
 lazy-object-proxy==1.12.0
     # via openapi-spec-validator
 license-expression==30.4.4
@@ -161,7 +143,6 @@ packageurl-python==0.17.6
     # via cyclonedx-python-lib
 packaging==26.3
     # via
-    #   kombu
     #   pip-audit
     #   pip-requirements-parser
     #   pytest
@@ -181,8 +162,6 @@ pluggy==1.6.0
     # via
     #   pytest
     #   pytest-cov
-prompt-toolkit==3.0.53
-    # via click-repl
 psycopg2-binary==2.9.12
     # via -r requirements.in
 py-serializable==2.1.0
@@ -210,8 +189,6 @@ pytest==9.1.1
     #   pytest-cov
 pytest-cov==7.1.0
     # via -r requirements-dev.in
-python-dateutil==2.9.0.post0
-    # via celery
 python-dotenv==1.2.2
     # via pydantic-settings
 python-multipart==0.0.32
@@ -244,9 +221,7 @@ rpds-py==2026.6.3
 ruff==0.16.2
     # via -r requirements-dev.in
 six==1.17.0
-    # via
-    #   python-dateutil
-    #   rfc3339-validator
+    # via rfc3339-validator
 sortedcontainers==2.4.0
     # via cyclonedx-python-lib
 sqlalchemy==2.0.51
@@ -278,23 +253,12 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-tzdata==2026.3
-    # via kombu
-tzlocal==5.4.4
-    # via celery
 urllib3==2.7.0
     # via requests
 uv==0.12.3
     # via -r requirements-dev.in
 uvicorn==0.52.1
     # via -r requirements.in
-vine==5.1.0
-    # via
-    #   amqp
-    #   celery
-    #   kombu
-wcwidth==0.8.2
-    # via prompt-toolkit
 werkzeug==3.1.8
     # via
     #   connexion

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-celery==5.6.3
 connexion[flask,swagger-ui]==3.3.0
 Flask==3.1.3
 Flask-Login==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ a2wsgi==1.10.10
     # via connexion
 alembic==1.19.0
     # via flask-migrate
-amqp==5.3.1
-    # via kombu
 annotated-types==0.8.0
     # via pydantic
 anyio==4.14.2
@@ -21,12 +19,8 @@ attrs==26.1.0
     #   jsonschema
     #   jsonschema-path
     #   referencing
-billiard==4.2.4
-    # via celery
 blinker==1.9.0
     # via flask
-celery==5.6.3
-    # via -r requirements.in
 certifi==2026.7.22
     # via
     #   httpcore
@@ -36,18 +30,8 @@ charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via
-    #   celery
-    #   click-didyoumean
-    #   click-plugins
-    #   click-repl
     #   flask
     #   uvicorn
-click-didyoumean==0.3.1
-    # via celery
-click-plugins==1.1.1.2
-    # via celery
-click-repl==0.3.0
-    # via celery
 connexion==3.3.0
     # via -r requirements.in
 flask==3.1.3
@@ -105,8 +89,6 @@ jsonschema-specifications==2025.9.1
     # via
     #   jsonschema
     #   openapi-schema-validator
-kombu==5.6.2
-    # via celery
 lazy-object-proxy==1.12.0
     # via openapi-spec-validator
 mako==1.4.1
@@ -128,12 +110,8 @@ openapi-schema-validator==0.9.0
     # via openapi-spec-validator
 openapi-spec-validator==0.9.0
     # via -r requirements.in
-packaging==26.3
-    # via kombu
 pathable==0.6.0
     # via jsonschema-path
-prompt-toolkit==3.0.53
-    # via click-repl
 psycopg2-binary==2.9.12
     # via -r requirements.in
 pydantic==2.13.4
@@ -147,8 +125,6 @@ pydantic-settings==2.14.2
     # via
     #   openapi-schema-validator
     #   openapi-spec-validator
-python-dateutil==2.9.0.post0
-    # via celery
 python-dotenv==1.2.2
     # via pydantic-settings
 python-multipart==0.0.32
@@ -175,9 +151,7 @@ rpds-py==2026.6.3
     #   jsonschema
     #   referencing
 six==1.17.0
-    # via
-    #   python-dateutil
-    #   rfc3339-validator
+    # via rfc3339-validator
 sqlalchemy==2.0.51
     # via
     #   alembic
@@ -199,21 +173,10 @@ typing-inspection==0.4.2
     # via
     #   pydantic
     #   pydantic-settings
-tzdata==2026.3
-    # via kombu
-tzlocal==5.4.4
-    # via celery
 urllib3==2.7.0
     # via requests
 uvicorn==0.52.1
     # via -r requirements.in
-vine==5.1.0
-    # via
-    #   amqp
-    #   celery
-    #   kombu
-wcwidth==0.8.2
-    # via prompt-toolkit
 werkzeug==3.1.8
     # via
     #   connexion


### PR DESCRIPTION
## Summary

- remove the unintegrated Celery scaffold from the production API
- remove Celery and its unused broker/CLI dependency graph from both compiled locks
- document that asynchronous work requires an owned job, retry, broker, observability, Compose, and CI contract before entering the runtime
- remove obsolete Celery beat ignore rules

## Why

Current `main` describes `app/celery/` as unintegrated. The trace confirmed that no route, model, command, test, Compose service, image command, or CI job imports or runs it. The five-line scaffold referenced a nonexistent `app.worker.test_celery` task and an AMQP host that the repository never provisions, while still adding Celery and its transitive broker stack to the production image.

This change aligns the shipped runtime with the repository's actual request-driven architecture instead of preserving speculative infrastructure.

## Dependency effect

- production lock: 69 packages -> 55 packages
- development lock: 101 packages -> 88 packages
- removed graph includes Celery, AMQP, Kombu, billiard, click broker helpers, timezone helpers, and related transitive packages
- no remaining application dependency changed version
- Renovate dashboard #100 reports no open or pending dependency branches

## Scope and non-scope

This removes only the unused worker scaffold and its dependency graph. It does not change OpenAPI routes, Flask/Connexion behavior, SQLAlchemy models, Alembic migrations, PostgreSQL configuration, Nginx, API ports, or published images. It does not prohibit a future worker; the README defines the evidence required to add one intentionally.

## Local validation

- Python 3.14 lock regeneration: deterministic for Linux
- Ruff: passed
- fast suite: 4 passed, PostgreSQL test skipped with its explicit integration-gate reason
- full PostgreSQL 18 suite: 5 passed, including Alembic upgrade/downgrade round-trip
- OpenAPI specification validator: passed
- `pip-audit -r requirements.txt`: no known vulnerabilities
- `docker compose config --quiet`: passed
- production image build from `python:3.14-slim`: passed
- image smoke: Celery absent, ASGI app import passed, unprivileged UID `10001` preserved
- `git diff --check`: passed

The disposable PostgreSQL test container was stopped and auto-removed after validation. It contained no persistent or user data.

## Dependency and merge order

The repository has no other open pull requests. This branch is based on current `main` `e4c676f` and has no cross-repository dependency. Re-read the head and base before merge.

## Hosted acceptance gate

Merge only if the exact current head passes CI's PostgreSQL 18 integration test, deterministic lock check, Ruff, full pytest suite, production audit, Compose validation, and Docker image build. Review all comments, threads, and check annotations first.

## Risk and rollback

The risk is an undocumented external process importing `app.celery.celery_app`; no repository-owned runtime or deployment path does so. Rollback is a revert of this commit, which restores the scaffold and compiled dependency graph. No image was published and no database was mutated outside the disposable test instance.

## Review focus

- evidence that the Celery boundary is genuinely unused
- correctness and determinism of both regenerated locks
- preservation of the API, database migration, container-user, and Compose contracts
- README guidance for any future asynchronous architecture
