### PR TITLE
Harden the read-only people API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
           uv pip compile --python-platform linux --python-version 3.14 --output-file=requirements.txt --strip-extras requirements.in
           uv pip compile --python-platform linux --python-version 3.14 --output-file=requirements-dev.txt --strip-extras requirements-dev.in
           git diff --exit-code -- requirements.txt requirements-dev.txt
-      - run: ruff check app manage.py unicorn.py test
+      - run: ruff check app manage.py unicorn.py test migrations/versions
+      - run: ruff format --check app manage.py unicorn.py test migrations/versions
+      - run: python -m openapi_spec_validator app/swagger.yaml
       - run: pytest -q
       - run: pip-audit -r requirements.txt
       - run: cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ OpenAPI-first NBA data service built with Python 3.14, Connexion 3, Flask 3, SQL
 PostgreSQL 18. Uvicorn serves the Connexion ASGI application; Docker Compose adds PostgreSQL and an
 Nginx reverse proxy.
 
-This repository currently exposes a small people API and the supporting application/database
-baseline. It is not yet the complete NBA statistics platform described by older versions of this
-README.
+This repository currently exposes a small, read-only people API and the supporting
+application/database baseline. It is not yet the complete NBA statistics platform described by
+older versions of this README.
 
 ## Architecture
 
@@ -20,7 +20,9 @@ client
           -> PostgreSQL 18
 ```
 
-- `app/swagger.yaml` is the authoritative OpenAPI route contract.
+- `app/swagger.yaml` is the authoritative OpenAPI route contract. Connexion rejects undeclared
+  query parameters, validates declared parameter ranges, and validates successful responses against
+  that contract.
 - `app/api/` implements OpenAPI `operationId` handlers.
 - `app/views/` owns HTML and non-OpenAPI Flask blueprints.
 - `app/models/` owns SQLAlchemy models and Marshmallow schemas.
@@ -79,9 +81,28 @@ Open:
 - landing page: http://localhost:5000/
 - Swagger UI: http://localhost:5000/api/ui/
 - people endpoint: http://localhost:5000/api/people
+- person detail endpoint: http://localhost:5000/api/people/1
 - legacy sample blueprint: http://localhost:5000/nbadata
 
 `/home` is login-protected, but the repository does not yet define a persistent user model.
+
+### People API boundary
+
+The public OpenAPI surface is intentionally read-only:
+
+- `GET /api/people` returns at most 50 records by default, accepts `limit=1..100` and a nonnegative
+  `offset`, and uses stable last-name, first-name, then id ordering.
+- `GET /api/people/{person_id}` returns one record or an RFC 7807-style 404 problem response.
+- Unknown query parameters and invalid ranges fail closed with `400 Bad Request`.
+- Person timestamps are stored and serialized as explicit UTC values that satisfy OpenAPI's
+  RFC 3339 `date-time` format.
+
+The repository does not expose create, update, or delete operations. Adding mutations requires an
+explicit authentication and authorization model, database uniqueness/nullability decisions,
+conflict semantics, and request/response tests; do not add a route merely because a handler once
+existed. This follows Connexion's documented
+[strict request and response validation](https://connexion.readthedocs.io/en/latest/validation.html)
+contract.
 
 ## Run the full stack
 
@@ -136,7 +157,8 @@ Fast local gate:
 
 ```bash
 python -m pytest -q
-ruff check app manage.py unicorn.py test
+ruff check app manage.py unicorn.py test migrations/versions
+ruff format --check app manage.py unicorn.py test migrations/versions
 python -m openapi_spec_validator app/swagger.yaml
 pip-audit -r requirements.txt
 docker compose config --quiet
@@ -151,9 +173,9 @@ export TEST_DATABASE_URL=postgresql://nbaapi:test-only@localhost:5432/nbaapi
 python -m pytest -q
 ```
 
-CI starts a disposable PostgreSQL 18 service, runs all tests, validates the Compose model, and builds
-the production image. The image contains only the runtime lockfile and runs as unprivileged UID
-`10001`.
+CI starts a disposable PostgreSQL 18 service, checks application, test, and migration formatting,
+validates the OpenAPI and Compose models, runs all tests, and builds the production image. The image
+contains only the runtime lockfile and runs as unprivileged UID `10001`.
 
 ## Contributing
 

--- a/app/README.md
+++ b/app/README.md
@@ -21,6 +21,11 @@ application.
 are created once at module level and initialized inside the factory so tests can
 construct isolated applications.
 
+The application registers `swagger.yaml` with strict parameter validation and
+response validation. OpenAPI handlers must therefore accept the declared Python
+arguments and return data matching the documented schema. Keep the people API
+read-only until an authentication and authorization contract exists.
+
 When adding an API route, update `swagger.yaml`, implement its `operationId`, and
 add a request test. Blueprint-only routes should be registered in
 `create_app()` and documented in the root README.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -32,7 +32,11 @@ def create_app(extra_config_settings=None):
         app.config.from_object("app.local_settings")
     app.config.update(extra_config_settings or {})
 
-    connexion_app.add_api("swagger.yaml")
+    connexion_app.add_api(
+        "swagger.yaml",
+        strict_validation=True,
+        validate_responses=True,
+    )
 
     ma.init_app(app)
     db.init_app(app)

--- a/app/api/people.py
+++ b/app/api/people.py
@@ -1,173 +1,27 @@
-"""
-This is the people module and supports all the REST actions for the
-people data
-"""
+"""Read-only OpenAPI operations for people data."""
 
-from flask import abort, make_response
+from flask import abort
 
 from app import db
 from app.models.nba_models import Person, PersonSchema
 
 
-def read_all():
-    """
-    This function responds to a request for /api/people
-    with the complete lists of people
-
-    :return:        json string of list of people
-    """
-    # Create the list of people from our data
-    people = Person.query.order_by(Person.lname).all()
-
-    # Serialize the data for the response
-    person_schema = PersonSchema(many=True)
-    data = person_schema.dump(people)
-    return data
+def read_all(limit=50, offset=0):
+    """Return a stable, bounded page of people."""
+    statement = (
+        db.select(Person)
+        .order_by(Person.lname, Person.fname, Person.person_id)
+        .limit(limit)
+        .offset(offset)
+    )
+    people = db.session.scalars(statement).all()
+    return PersonSchema(many=True).dump(people)
 
 
 def read_one(person_id):
-    """
-    This function responds to a request for /api/people/{person_id}
-    with one matching person from people
+    """Return one person or an explicit 404 problem response."""
+    person = db.session.get(Person, person_id)
+    if person is None:
+        abort(404, description=f"Person not found for Id: {person_id}")
 
-    :param person_id:   Id of person to find
-    :return:            person matching id
-    """
-    # Get the person requested
-    person = Person.query.filter(Person.person_id == person_id).one_or_none()
-
-    # Did we find a person?
-    if person is not None:
-
-        # Serialize the data for the response
-        person_schema = PersonSchema()
-        data = person_schema.dump(person)
-        return data
-
-    # Otherwise, nope, didn't find that person
-    else:
-        abort(
-            404, f"Person not found for Id: {person_id}",
-        )
-
-
-def create(person):
-    """
-    This function creates a new person in the people structure
-    based on the passed in person data
-
-    :param person:  person to create in people structure
-    :return:        201 on success, 406 on person exists
-    """
-    fname = person.get("fname")
-    lname = person.get("lname")
-
-    existing_person = (
-        Person.query.filter(Person.fname == fname)
-        .filter(Person.lname == lname)
-        .one_or_none()
-    )
-
-    # Can we insert this person?
-    if existing_person is None:
-
-        # Create a person instance using the schema and the passed in person
-        schema = PersonSchema()
-        new_person = schema.load(person, session=db.session)
-
-        # Add the person to the database
-        db.session.add(new_person)
-        db.session.commit()
-
-        # Serialize and return the newly created person in the response
-        data = schema.dump(new_person)
-
-        return data, 201
-
-    # Otherwise, nope, person exists already
-    else:
-        abort(
-            409,
-            f"Person {fname} {lname} exists already",
-        )
-
-
-def update(person_id, person):
-    """
-    This function updates an existing person in the people structure
-    Throws an error if a person with the name we want to update to
-    already exists in the database.
-
-    :param person_id:   Id of the person to update in the people structure
-    :param person:      person to update
-    :return:            updated person structure
-    """
-    # Get the person requested from the db into session
-    update_person = Person.query.filter(Person.person_id == person_id).one_or_none()
-
-    # Try to find an existing person with the same name as the update
-    fname = person.get("fname")
-    lname = person.get("lname")
-
-    existing_person = (
-        Person.query.filter(Person.fname == fname)
-        .filter(Person.lname == lname)
-        .one_or_none()
-    )
-
-    # Are we trying to find a person that does not exist?
-    if update_person is None:
-        abort(
-            404, f"Person not found for Id: {person_id}",
-        )
-
-    # Would our update create a duplicate of another person already existing?
-    elif existing_person is not None and existing_person.person_id != person_id:
-        abort(
-            409,
-            f"Person {fname} {lname} exists already",
-        )
-
-    # Otherwise go ahead and update!
-    else:
-
-        # turn the passed in person into a db object
-        schema = PersonSchema()
-        update = schema.load(person, session=db.session)
-
-        # Set the id to the person we want to update
-        update.person_id = update_person.person_id
-
-        # merge the new object into the old and commit it to the db
-        db.session.merge(update)
-        db.session.commit()
-
-        # return updated person in the response
-        data = schema.dump(update_person)
-
-        return data, 200
-
-
-def delete(person_id):
-    """
-    This function deletes a person from the people structure
-
-    :param person_id:   Id of the person to delete
-    :return:            200 on successful delete, 404 if not found
-    """
-    # Get the person requested
-    person = Person.query.filter(Person.person_id == person_id).one_or_none()
-
-    # Did we find a person?
-    if person is not None:
-        db.session.delete(person)
-        db.session.commit()
-        return make_response(
-            f"Person {person_id} deleted", 200
-        )
-
-    # Otherwise, nope, didn't find that person
-    else:
-        abort(
-            404, f"Person not found for Id: {person_id}",
-        )
+    return PersonSchema().dump(person)

--- a/app/models/nba_models.py
+++ b/app/models/nba_models.py
@@ -1,6 +1,18 @@
-from datetime import datetime
+from datetime import UTC, datetime
+
+from marshmallow import fields, post_dump
 
 from app import db, ma
+
+
+def serialize_utc_timestamp(person):
+    """Serialize database timestamps as RFC 3339 UTC values."""
+    value = person.timestamp
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()
 
 
 class Person(db.Model):
@@ -9,11 +21,22 @@ class Person(db.Model):
     lname = db.Column(db.String(32))
     fname = db.Column(db.String(32))
     timestamp = db.Column(
-        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
     )
 
 
 class PersonSchema(ma.SQLAlchemyAutoSchema):
+    timestamp = fields.Function(serialize=serialize_utc_timestamp, dump_only=True)
+
+    @post_dump
+    def omit_unknown_timestamp(self, data, **_kwargs):
+        """Do not emit an invalid date-time for nullable legacy rows."""
+        if data.get("timestamp") is None:
+            data.pop("timestamp", None)
+        return data
+
     class Meta:
         model = Person
         sqla_session = db.session

--- a/app/swagger.yaml
+++ b/app/swagger.yaml
@@ -18,23 +18,89 @@ paths:
       tags:
         - People
       summary: Read the entire set of people, sorted by last name
-      description: Read the entire set of people, sorted by last name
+      description: Read a bounded page of people with stable last-name, first-name, and id ordering
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of people to return
+          required: false
+          type: integer
+          format: int32
+          default: 50
+          minimum: 1
+          maximum: 100
+        - name: offset
+          in: query
+          description: Number of ordered people to skip
+          required: false
+          type: integer
+          format: int32
+          default: 0
+          minimum: 0
       responses:
         200:
-          description: Successfully read people set operation
+          description: A stable, bounded page of people
           schema:
             type: array
             items:
-              properties:
-                person_id:
-                  type: string
-                  description: Id of the person
-                fname:
-                  type: string
-                  description: First name of the person
-                lname:
-                  type: string
-                  description: Last name of the person
-                timestamp:
-                  type: string
-                  description: Creation/Update timestamp of the person
+              $ref: "#/definitions/Person"
+        400:
+          description: Invalid or unknown query parameter
+          schema:
+            $ref: "#/definitions/Problem"
+  /people/{person_id}:
+    get:
+      operationId: app.api.people.read_one
+      tags:
+        - People
+      summary: Read one person by id
+      parameters:
+        - name: person_id
+          in: path
+          description: Numeric person identifier
+          required: true
+          type: integer
+          format: int64
+          minimum: 1
+      responses:
+        200:
+          description: The requested person
+          schema:
+            $ref: "#/definitions/Person"
+        404:
+          description: Person does not exist
+          schema:
+            $ref: "#/definitions/Problem"
+
+definitions:
+  Person:
+    type: object
+    properties:
+      person_id:
+        type: integer
+        format: int64
+        description: Person identifier
+      fname:
+        type: string
+        description: First name
+      lname:
+        type: string
+        description: Last name
+      timestamp:
+        type: string
+        format: date-time
+        description: Creation or update timestamp
+  Problem:
+    type: object
+    required:
+      - title
+      - status
+    properties:
+      type:
+        type: string
+      title:
+        type: string
+      status:
+        type: integer
+      detail:
+        type: string

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -17,6 +17,12 @@ application schema, while a PostgreSQL 13-to-18 move requires a verified
 database backup/restore or `pg_upgrade` process outside this repository.
 
 `versions/3f45a7d8b2c1_create_person_table.py` is the checked-in schema baseline.
+The following UTC timestamp revision interprets existing naive PostgreSQL values
+as UTC before converting them to `timestamp with time zone`; its downgrade
+converts values back through UTC. This keeps the database type aligned with the
+OpenAPI `date-time` response contract. SQLite has no timezone-aware storage type,
+so the revision is intentionally a schema no-op there; the response schema still
+attaches UTC to its legacy naive values.
 The development-only `flask --app manage init-db` command bypasses migration
 history and recreates the schema destructively.
 

--- a/migrations/versions/5b8f2a4d91c0_use_utc_person_timestamps.py
+++ b/migrations/versions/5b8f2a4d91c0_use_utc_person_timestamps.py
@@ -1,0 +1,39 @@
+"""Store person timestamps with an explicit UTC-aware type.
+
+Revision ID: 5b8f2a4d91c0
+Revises: 3f45a7d8b2c1
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "5b8f2a4d91c0"
+down_revision = "3f45a7d8b2c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    op.alter_column(
+        "person",
+        "timestamp",
+        existing_type=sa.DateTime(),
+        type_=sa.DateTime(timezone=True),
+        existing_nullable=True,
+        postgresql_using="timestamp AT TIME ZONE 'UTC'",
+    )
+
+
+def downgrade():
+    if op.get_bind().dialect.name != "postgresql":
+        return
+    op.alter_column(
+        "person",
+        "timestamp",
+        existing_type=sa.DateTime(timezone=True),
+        type_=sa.DateTime(),
+        existing_nullable=True,
+        postgresql_using="timestamp AT TIME ZONE 'UTC'",
+    )

--- a/test/README.md
+++ b/test/README.md
@@ -6,9 +6,16 @@ Run the test suite from the repository root:
 pytest -q
 ```
 
-`test_app.py` covers the rendered landing page and the OpenAPI people endpoint
-using a temporary SQLite database. It also contains a PostgreSQL integration
-test that is skipped unless `TEST_DATABASE_URL` is set with an explicit reason.
+`test_app.py` covers the rendered landing page and the OpenAPI people collection
+and detail endpoints using a temporary SQLite database. The API cases pin stable
+ordering, the default and maximum page boundary, strict rejection of invalid or
+unknown query parameters, and the not-found problem response. The module also
+contains a PostgreSQL integration test that is skipped unless `TEST_DATABASE_URL`
+is set with an explicit reason.
+
+The SQLite gate also applies every checked-in migration and downgrades to the
+empty base. PostgreSQL CI additionally verifies that the timestamp column is a
+timezone-aware database type.
 
 CI starts PostgreSQL 18 and uses:
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,3 @@
 # __init__.py is a special Python file that allows a directory to become
 # a Python package so it can be accessed using the 'import' statement.
-
 # Intentionally left empty

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -9,6 +9,7 @@ from flask_migrate import downgrade, upgrade
 from sqlalchemy import inspect, text
 
 from app import create_app, db
+from app.models.nba_models import Person
 
 
 @pytest.fixture()
@@ -41,11 +42,63 @@ def test_people_endpoint_uses_openapi_route(application):
     assert response.json() == []
 
 
+def test_people_endpoint_is_stably_ordered_and_bounded(application):
+    with application.app.app_context():
+        db.session.add_all(
+            [
+                Person(fname=f"First {index:02d}", lname=f"Last {index % 3}")
+                for index in range(60)
+            ]
+        )
+        db.session.commit()
+
+    response = application.test_client().get("/api/people")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 50
+    ordered_names = [(person["lname"], person["fname"]) for person in response.json()]
+    assert ordered_names == sorted(ordered_names)
+
+    final_page = application.test_client().get("/api/people?limit=10&offset=50")
+    assert final_page.status_code == 200
+    assert len(final_page.json()) == 10
+
+
+def test_people_endpoint_rejects_invalid_or_unknown_query_parameters(application):
+    client = application.test_client()
+
+    assert client.get("/api/people?limit=0").status_code == 400
+    assert client.get("/api/people?limit=101").status_code == 400
+    assert client.get("/api/people?unexpected=true").status_code == 400
+
+
+def test_person_detail_endpoint_returns_one_or_404(application):
+    with application.app.app_context():
+        person = Person(fname="Ja", lname="Morant")
+        db.session.add(person)
+        db.session.commit()
+        person_id = person.person_id
+
+    client = application.test_client()
+    found = client.get(f"/api/people/{person_id}")
+    missing = client.get("/api/people/999999")
+
+    assert found.status_code == 200
+    assert found.json()["person_id"] == person_id
+    assert found.json()["fname"] == "Ja"
+    assert found.json()["lname"] == "Morant"
+    assert found.json()["timestamp"].endswith("+00:00")
+    assert missing.status_code == 404
+    assert missing.json()["status"] == 404
+
+
 def test_openapi_contract_identifies_the_service():
     specification = yaml.safe_load(Path("app/swagger.yaml").read_text(encoding="utf-8"))
 
     assert specification["info"]["title"] == "NBA Data API"
     assert "/people" in specification["paths"]
+    assert "/people/{person_id}" in specification["paths"]
+    assert specification["paths"]["/people"]["get"]["parameters"][0]["maximum"] == 100
 
 
 def test_legacy_sample_blueprint_remains_available(application):
@@ -53,6 +106,22 @@ def test_legacy_sample_blueprint_remains_available(application):
 
     assert response.status_code == 200
     assert response.json() == {"sample return": 10}
+
+
+def test_sqlite_schema_round_trip(tmp_path):
+    database_path = tmp_path / "nbaapi-migration-test.db"
+    connexion_app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{database_path}",
+        }
+    )
+
+    with connexion_app.app.app_context():
+        upgrade()
+        assert inspect(db.engine).has_table("person")
+        downgrade(revision="base")
+        assert not inspect(db.engine).has_table("person")
 
 
 @pytest.mark.integration
@@ -78,4 +147,10 @@ def test_postgres_18_schema_round_trip():
 
         upgrade()
         assert inspect(db.engine).has_table("person")
+        timestamp_column = next(
+            column
+            for column in inspect(db.engine).get_columns("person")
+            if column["name"] == "timestamp"
+        )
+        assert timestamp_column["type"].timezone is True
         downgrade(revision="base")


### PR DESCRIPTION
## Summary

- make the published people API explicitly read-only and remove unreachable unauthenticated mutation handlers
- add a documented single-person GET plus bounded, stable collection pagination
- enable Connexion strict request validation and response validation
- align Python 3.14, Marshmallow, OpenAPI, SQLite, and PostgreSQL timestamp behavior around explicit UTC
- refine root, application, migration, and test READMEs with the architecture and release boundaries

## Root cause

`app/swagger.yaml` exposed only `GET /api/people`, while `app/api/people.py` retained unreachable create, update, delete, and single-record functions from the legacy scaffold. That made the intended API boundary ambiguous without providing authenticated write behavior.

Turning on response validation then exposed a second contract bug: SQLAlchemy/SQLite returned naive timestamp values, while OpenAPI declared RFC 3339 `date-time`. The existing `datetime.utcnow()` default is also deprecated under Python 3.14.

## API and persistence contract

- `GET /api/people` defaults to 50 records, caps `limit` at 100, accepts a nonnegative `offset`, and orders by last name, first name, then id.
- `GET /api/people/{person_id}` returns one record or an RFC 7807-style 404.
- undeclared query parameters and out-of-range values fail closed with 400.
- successful responses are validated against the OpenAPI schema.
- timestamps use aware UTC defaults and serialize with an explicit `+00:00` offset.
- the new Alembic revision interprets legacy PostgreSQL naive timestamps as UTC before converting to `timestamp with time zone`; SQLite is a documented schema no-op because it has no timezone-aware storage type.

Connexion documents both [strict request validation and response validation](https://connexion.readthedocs.io/en/latest/validation.html). The implementation keeps mutations out of the public surface until authentication, authorization, uniqueness/nullability, conflict, and audit semantics are designed together.

## Dependency review

The Renovate dashboard reports no open or pending branches. Both production and development locks reproduce exactly with the pinned `uv pip compile` commands. `pip-audit -r requirements.txt` reports no known vulnerabilities. No dependency change is needed for this work.

## Validation

- Python 3.14.4 isolated environment installed from `requirements-dev.txt`
- `ruff check app manage.py unicorn.py test migrations/versions`
- `ruff format --check app manage.py unicorn.py test migrations/versions`
- `python -m openapi_spec_validator app/swagger.yaml`
- `python -m pytest -q`: 8 passed, 1 PostgreSQL integration test skipped locally by contract
- both `uv pip compile` lock freshness checks: no diff
- `pip-audit -r requirements.txt`: no known vulnerabilities
- `docker compose config --quiet`
- migrated SQLite HTTP smoke:
  - collection: 200 JSON
  - undeclared query parameter: 400 `application/problem+json`
  - missing person: 404 `application/problem+json`
- `git diff --check`

Hosted CI run [31286581709](https://github.com/JovaniPink/awesome-nba-data-api/actions/runs/31286581709) passed at exact head `346c03ad7005156c5b4f3f8df705dcd4a20a514e`:

- PostgreSQL 18.4 service healthy
- Ruff lint and formatting gates passed across the application, tests, and migrations
- OpenAPI document validated
- 9 tests passed, including the PostgreSQL upgrade/type/downgrade integration test
- production dependency audit found no known vulnerabilities
- Compose model validated
- production image built as `sha256:3e4f088fa85fb9f3737bd08964c4a50d243f3b5e8feb7290ab77d1d6503b6a67`

The local Docker daemon was unavailable; hosted CI supplies the PostgreSQL and image-build evidence.

## Non-scope

- no create, update, or delete endpoint
- no user/authentication model
- no name uniqueness or nullability migration
- no production credentials, deployment, PostgreSQL volume, or live database operation
- no suppression of upstream Connexion/jsonschema deprecation warnings

## Risk and rollback

- Collection clients that relied on an unbounded response now receive at most 50 records unless they request a larger allowed page.
- Strict validation rejects previously ignored query typos.
- The PostgreSQL migration changes timestamp storage semantics by explicitly interpreting legacy naive values as UTC.

Roll back by reverting the merge commit and applying the Alembic downgrade only after reviewing downstream timestamp consumers. Source rollback and database rollback are separate operations.

## Review focus

- whether 50/100 are appropriate initial page boundaries
- whether the read-only surface is explicit enough
- whether legacy naive PostgreSQL timestamps should be interpreted as UTC
- any downstream client that currently assumes an unbounded collection response
