### PR TITLE
Migrate the executable API contract to OpenAPI 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ client
           -> PostgreSQL 18
 ```
 
-- `app/swagger.yaml` is the authoritative OpenAPI route contract. Connexion rejects undeclared
+- `app/swagger.yaml` is the authoritative OpenAPI 3.0.3 route contract. Connexion rejects undeclared
   query parameters, validates declared parameter ranges, and validates successful responses against
   that contract.
 - `app/api/` implements OpenAPI `operationId` handlers.
@@ -118,6 +118,11 @@ conflict semantics, and request/response tests; do not add a route merely becaus
 existed. This follows Connexion's documented
 [strict request and response validation](https://connexion.readthedocs.io/en/latest/validation.html)
 contract.
+
+The contract uses OpenAPI 3 response media types and reusable schemas rather
+than the legacy Swagger 2 `produces`/`definitions` model. Problem responses are
+declared as `application/problem+json`; successful reads remain
+`application/json`.
 
 ## Run the full stack
 

--- a/app/README.md
+++ b/app/README.md
@@ -14,7 +14,7 @@ application.
 | `templates/` | Jinja templates for HTML routes. |
 | `views/` | Flask blueprints outside the OpenAPI contract. |
 | `settings.py` | Environment-backed Flask and database settings. |
-| `swagger.yaml` | Authoritative OpenAPI route contract. |
+| `swagger.yaml` | Authoritative OpenAPI 3.0.3 route contract. |
 
 `create_app()` in `app/__init__.py` returns a `connexion.FlaskApp`. Use
 `connexion_app.app` when an API requires the underlying Flask object. Extensions

--- a/app/api/people.py
+++ b/app/api/people.py
@@ -5,6 +5,8 @@ from flask import abort
 from app import db
 from app.models.nba_models import Person, PersonSchema
 
+JSON_RESPONSE_HEADERS = {"Content-Type": "application/json"}
+
 
 def read_all(limit=50, offset=0):
     """Return a stable, bounded page of people."""
@@ -15,7 +17,7 @@ def read_all(limit=50, offset=0):
         .offset(offset)
     )
     people = db.session.scalars(statement).all()
-    return PersonSchema(many=True).dump(people)
+    return PersonSchema(many=True).dump(people), 200, JSON_RESPONSE_HEADERS
 
 
 def read_one(person_id):
@@ -24,4 +26,4 @@ def read_one(person_id):
     if person is None:
         abort(404, description=f"Person not found for Id: {person_id}")
 
-    return PersonSchema().dump(person)
+    return PersonSchema().dump(person), 200, JSON_RESPONSE_HEADERS

--- a/app/swagger.yaml
+++ b/app/swagger.yaml
@@ -1,16 +1,12 @@
-swagger: "2.0"
+openapi: 3.0.3
 info:
-  description: OpenAPI contract for the NBA data service
-  version: "1.0.0"
   title: NBA Data API
-consumes:
-  - application/json
-produces:
-  - application/json
+  description: OpenAPI contract for the NBA data service
+  version: 1.0.0
 
-basePath: /api
+servers:
+  - url: /api
 
-# Paths supported by the server application
 paths:
   /people:
     get:
@@ -24,30 +20,36 @@ paths:
           in: query
           description: Maximum number of people to return
           required: false
-          type: integer
-          format: int32
-          default: 50
-          minimum: 1
-          maximum: 100
+          schema:
+            type: integer
+            format: int32
+            default: 50
+            minimum: 1
+            maximum: 100
         - name: offset
           in: query
           description: Number of ordered people to skip
           required: false
-          type: integer
-          format: int32
-          default: 0
-          minimum: 0
+          schema:
+            type: integer
+            format: int32
+            default: 0
+            minimum: 0
       responses:
-        200:
+        "200":
           description: A stable, bounded page of people
-          schema:
-            type: array
-            items:
-              $ref: "#/definitions/Person"
-        400:
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Person"
+        "400":
           description: Invalid or unknown query parameter
-          schema:
-            $ref: "#/definitions/Problem"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
   /people/{person_id}:
     get:
       operationId: app.api.people.read_one
@@ -59,48 +61,56 @@ paths:
           in: path
           description: Numeric person identifier
           required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "200":
+          description: The requested person
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Person"
+        "404":
+          description: Person does not exist
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        person_id:
           type: integer
           format: int64
-          minimum: 1
-      responses:
-        200:
-          description: The requested person
-          schema:
-            $ref: "#/definitions/Person"
-        404:
-          description: Person does not exist
-          schema:
-            $ref: "#/definitions/Problem"
-
-definitions:
-  Person:
-    type: object
-    properties:
-      person_id:
-        type: integer
-        format: int64
-        description: Person identifier
-      fname:
-        type: string
-        description: First name
-      lname:
-        type: string
-        description: Last name
-      timestamp:
-        type: string
-        format: date-time
-        description: Creation or update timestamp
-  Problem:
-    type: object
-    required:
-      - title
-      - status
-    properties:
-      type:
-        type: string
-      title:
-        type: string
-      status:
-        type: integer
-      detail:
-        type: string
+          description: Person identifier
+        fname:
+          type: string
+          nullable: true
+          description: First name
+        lname:
+          type: string
+          nullable: true
+          description: Last name
+        timestamp:
+          type: string
+          format: date-time
+          description: Creation or update timestamp
+    Problem:
+      type: object
+      required:
+        - title
+        - status
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+        detail:
+          type: string

--- a/docs/architecture-investigation.md
+++ b/docs/architecture-investigation.md
@@ -31,7 +31,7 @@ The useful architecture must:
 
 | Area | Evidence in this repository | Assessment |
 | --- | --- | --- |
-| HTTP contract | Connexion and `app/swagger.yaml`; strict parameter and response validation | Good boundary, although the contract is still OpenAPI/Swagger 2.0 |
+| HTTP contract | Connexion and OpenAPI 3.0.3 in `app/swagger.yaml`; strict parameter and response validation | Good executable boundary |
 | Runtime | Uvicorn, Flask/Connexion, SQLAlchemy, Alembic, PostgreSQL 18 | Coherent conventional service stack |
 | Public domain | Two read-only `Person` endpoints | Placeholder, not an NBA product vertical |
 | Legacy surface | HTML/login scaffolding and `/nbadata` sample route | Retire as real domain routes replace it |
@@ -103,8 +103,8 @@ semantics are product behavior, not metadata decoration.
    change.
 4. Add keyset pagination only when list size makes offset pagination measurably inadequate.
 5. Remove the `Person`, login-page, and sample-blueprint scaffolding when no longer used.
-6. Migrate the contract from Swagger 2.0 to OpenAPI 3.x as a bounded compatibility change, not as a
-   prerequisite to the first NBA endpoint. Connexion supports both formats.
+6. Preserve the OpenAPI 3 contract and its request/response validation as real NBA resources replace
+   the placeholder people surface.
 
 Nginx is optional for local development and may eventually become a deployment-profile concern.
 It is not currently the major source of complexity, so removing it is lower value than creating a

--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,8 @@ pytest -q
 `test_app.py` covers the rendered landing page and the OpenAPI people collection
 and detail endpoints using a temporary SQLite database. The API cases pin stable
 ordering, the default and maximum page boundary, strict rejection of invalid or
-unknown query parameters, and the not-found problem response. The module also
+unknown query parameters, the OpenAPI 3.0.3 contract shape, explicit success and
+problem media types, and the not-found problem response. The module also
 contains a PostgreSQL integration test that is skipped unless `TEST_DATABASE_URL`
 is set with an explicit reason.
 

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -39,6 +39,7 @@ def test_people_endpoint_uses_openapi_route(application):
     response = application.test_client().get("/api/people")
 
     assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
     assert response.json() == []
 
 
@@ -67,9 +68,16 @@ def test_people_endpoint_is_stably_ordered_and_bounded(application):
 def test_people_endpoint_rejects_invalid_or_unknown_query_parameters(application):
     client = application.test_client()
 
-    assert client.get("/api/people?limit=0").status_code == 400
-    assert client.get("/api/people?limit=101").status_code == 400
-    assert client.get("/api/people?unexpected=true").status_code == 400
+    responses = [
+        client.get("/api/people?limit=0"),
+        client.get("/api/people?limit=101"),
+        client.get("/api/people?unexpected=true"),
+    ]
+    assert all(response.status_code == 400 for response in responses)
+    assert all(
+        response.headers["content-type"] == "application/problem+json"
+        for response in responses
+    )
 
 
 def test_person_detail_endpoint_returns_one_or_404(application):
@@ -84,21 +92,38 @@ def test_person_detail_endpoint_returns_one_or_404(application):
     missing = client.get("/api/people/999999")
 
     assert found.status_code == 200
+    assert found.headers["content-type"] == "application/json"
     assert found.json()["person_id"] == person_id
     assert found.json()["fname"] == "Ja"
     assert found.json()["lname"] == "Morant"
     assert found.json()["timestamp"].endswith("+00:00")
     assert missing.status_code == 404
+    assert missing.headers["content-type"] == "application/problem+json"
     assert missing.json()["status"] == 404
 
 
 def test_openapi_contract_identifies_the_service():
     specification = yaml.safe_load(Path("app/swagger.yaml").read_text(encoding="utf-8"))
 
+    assert specification["openapi"] == "3.0.3"
+    assert "swagger" not in specification
     assert specification["info"]["title"] == "NBA Data API"
+    assert specification["servers"] == [{"url": "/api"}]
     assert "/people" in specification["paths"]
     assert "/people/{person_id}" in specification["paths"]
-    assert specification["paths"]["/people"]["get"]["parameters"][0]["maximum"] == 100
+    assert (
+        specification["paths"]["/people"]["get"]["parameters"][0]["schema"]["maximum"]
+        == 100
+    )
+    assert (
+        specification["paths"]["/people"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]["items"]["$ref"]
+        == "#/components/schemas/Person"
+    )
+    assert "definitions" not in specification
+    for operations in specification["paths"].values():
+        assert set(operations).isdisjoint({"post", "put", "patch", "delete"})
 
 
 def test_legacy_sample_blueprint_remains_available(application):


### PR DESCRIPTION
## Rationale

The active architecture investigation in #122 identified the executable Swagger 2 document as a bounded compatibility debt. Connexion 3.3's official quickstart uses OpenAPI 3, and the current OpenAPI validator supports 3.0.3. This change modernizes that boundary before real NBA resources replace the placeholder people surface.

## Scope

- migrate `app/swagger.yaml` from Swagger 2 to OpenAPI 3.0.3
- replace `basePath`, `produces`, and `definitions` with `servers`, response `content`, and `components.schemas`
- preserve the exact `/api/people` and `/api/people/{person_id}` paths, parameters, operation IDs, status codes, and read-only behavior
- declare successful responses as `application/json` and RFC 7807 responses as `application/problem+json`
- explicitly return the successful media type from handlers because Connexion requires disambiguation when an operation declares multiple response media types
- allow the existing nullable legacy first/last-name values without weakening route validation
- extend contract/request tests and update the root, application, test, and architecture documentation

## Architecture and user flow

`app/swagger.yaml` remains the single HTTP authority. Connexion still mounts it under `/api`, performs strict request validation, resolves the same handlers, and validates responses. Swagger UI now reads the generated `/api/openapi.json` as OAS3.

This does not add mutations. Issue #121 was closed as not planned after #122 established the read-only architecture; #123 owns the governed NBA vertical that will eventually replace the placeholder routes.

## Exact-head validation

Exact local and remote head: `c4e115f43642112421da4542610499cf7d1fb9a0`

- Linux/Python 3.14 runtime and development locks regenerated byte-for-byte
- Ruff lint: passed
- Ruff format check: passed for 20 Python files
- `openapi_spec_validator`: OpenAPI 3.0.3 document passed
- pytest: 8 passed; the PostgreSQL-only integration test was explicitly skipped locally
- production dependency audit: no known vulnerabilities
- Docker Compose configuration: passed
- SQLite Alembic upgrade: passed
- live Uvicorn smoke:
  - `GET /api/people`: 200 `application/json`
  - missing person: 404 `application/problem+json`
  - Swagger UI: 200 and visually rendered the OAS3 badge, both read operations, and both schemas
  - `GET /api/openapi.json`: 200 and reports `openapi: 3.0.3`
- `git diff --check`: passed
- hosted PostgreSQL 18 migration/integration gate: passed
- hosted Compose validation and production image build: passed

The local Docker daemon was unavailable; exact-head hosted CI supplied the PostgreSQL 18 and production-image evidence.

## Research basis

- [Connexion official quickstart](https://connexion.readthedocs.io/en/stable/quickstart.html)
- [OpenAPI Specification 3.0.3](https://spec.openapis.org/oas/v3.0.3.html)

## Non-scope

- no authentication or mutation operations
- no database migration or model change
- no dependency update
- no route, pagination, deployment, or source-acquisition change
- no retirement of placeholder routes before #123 has a proven replacement

## Risks and rollback

The main compatibility risk is Connexion response/media-type behavior. Request tests, live Uvicorn responses, generated JSON, and rendered Swagger UI cover that boundary; exact-head hosted CI additionally covers PostgreSQL 18 and the production image.

Rollback is a revert of the eventual merge commit; there is no database or deployment-state rollback.

## Release boundary and merge order

Hosted CI passed the exact current head, including PostgreSQL 18 migrations/tests and the production image build. This PR can merge independently before #123 implementation because it preserves the existing route contract. Do not treat its merge as source approval, a new NBA vertical, or production deployment proof.

## Review focus

- OpenAPI 3 path/server equivalence
- success versus problem media types
- Connexion handler return contract
- preservation of strict unknown-parameter rejection
- documentation consistency and continued read-only scope
