### PR TITLE
Archive superseded NBA API scaffold

### DIFF
--- a/ARCHIVE_NOTICE.md
+++ b/ARCHIVE_NOTICE.md
@@ -1,0 +1,27 @@
+# Archive notice
+
+This repository was superseded and archived on August 13, 2026.
+
+## Replacements
+
+- [awesome-nba-data](https://github.com/JovaniPink/awesome-nba-data) is the maintained public
+  source and tooling catalog.
+- [nba-lab](https://github.com/JovaniPink/nba-lab) is the private, two-person, fixture-backed
+  product and governed data-contract repository.
+
+NBA Lab v1 does not copy or depend on this Flask/Connexion service. It has no public HTTP API and
+does not carry forward the placeholder `Person` routes, Nginx deployment shape, or legacy samples.
+
+## Archive safety review
+
+Reviewed August 13, 2026 before the owner archive action:
+
+- local and GitHub code searches found no external runtime consumer; the one public profile link
+  was changed to the maintained catalog;
+- GitHub reported no releases, deployments, environments, or Pages site;
+- the only Actions workflow is repository-local CI, not a deployment or downstream trigger;
+- no published package was identified as a consumer or release boundary;
+- all Git history, tests, migrations, and design evidence remain preserved.
+
+Archiving is intentionally non-destructive: no repository deletion, history rewrite, or data copy
+is part of this decision.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 # NBA Data API
 
-OpenAPI-first NBA data service built with Python 3.14, Connexion 3, Flask 3, SQLAlchemy 2, and
-PostgreSQL 18. Uvicorn serves the Connexion ASGI application; Docker Compose adds PostgreSQL and an
-Nginx reverse proxy.
+> [!IMPORTANT]
+> **Archived on August 13, 2026.** Source discovery continues in
+> [awesome-nba-data](https://github.com/JovaniPink/awesome-nba-data). The private,
+> fixture-backed product and governed data contracts now live in
+> [nba-lab](https://github.com/JovaniPink/nba-lab). This repository is preserved as
+> historical API scaffolding; it is not a service boundary or runtime dependency.
+
+This repository contains an OpenAPI-first NBA data service scaffold built with Python 3.14,
+Connexion 3, Flask 3, SQLAlchemy 2, and PostgreSQL 18. It is preserved without history rewriting or
+deletion.
 
 This repository currently exposes a small, read-only people API and the supporting
 application/database baseline. It is not yet the complete NBA statistics platform described by
@@ -10,18 +17,16 @@ older versions of this README.
 
 ## Architecture status
 
-This repository is the active **serving boundary** for the NBA project family. The current stack is
-deliberately request-driven; its target is to serve governed, read-only facts and, later,
-precomputed model outputs. It does not scrape sources, train models, or run an unbounded workflow
-in an HTTP request.
+This repository is **not active**. NBA Lab is the one full-stack product and data-contract boundary;
+the public catalog remains separate. The Flask `Person` routes, Compose stack, and OpenAPI surface
+below are historical implementation evidence, not a supported public API or deployment.
 
-The supporting infrastructure is ahead of the current `Person` placeholder domain, but it is not a
-reason to rewrite the service. The next useful work is to add one governed NBA vertical with source
-lineage and tests, then remove the placeholder routes that it replaces. Do not restore Celery,
-RabbitMQ, or a separate worker until a measured workload requires asynchronous execution.
+Do not restore Celery, RabbitMQ, the placeholder routes, or a separate API in NBA Lab. Useful domain
+and lineage decisions may be reproduced there with tests; this repository itself stays archived.
 
-See [`docs/architecture-investigation.md`](docs/architecture-investigation.md) for the evidence,
-cross-repository boundaries, target data flow, rejected alternatives, and decision gates.
+See [`ARCHIVE_NOTICE.md`](ARCHIVE_NOTICE.md) for the preservation and dependency audit, and
+[`docs/architecture-investigation.md`](docs/architecture-investigation.md) for the superseded design
+record.
 
 ## Architecture
 

--- a/docs/architecture-investigation.md
+++ b/docs/architecture-investigation.md
@@ -2,11 +2,15 @@
 
 _Reviewed: 2026-08-11_
 
+> **Superseded August 13, 2026.** The four-repository boundary evaluated below was replaced by
+> [awesome-nba-data](https://github.com/JovaniPink/awesome-nba-data) plus the private
+> [nba-lab](https://github.com/JovaniPink/nba-lab). This document remains historical evidence; its
+> recommendation to keep this API active is no longer current.
+
 ## Decision
 
-Keep this repository as the active, read-only NBA serving service. Evolve it incrementally; do not
-replace it with a distributed platform and do not put ingestion or model training in the request
-path.
+Archive this repository without deleting or rewriting it. Do not carry its placeholder Flask
+routes, standalone API boundary, or deployment scaffolding into NBA Lab.
 
 The stack is infrastructure-heavy relative to the two current `Person` endpoints, but it is not
 architecturally incoherent. The application has an executable API contract, migrations, request and
@@ -49,12 +53,12 @@ without answering a current product question.
 | --- | --- | --- |
 | `awesome-nba-data` | Curated catalog of sources and tools | Runtime dependency or copied data warehouse |
 | `nba-data` | Historical research archive and source-discovery reference | Live ingestion system or authoritative current dataset |
-| `awesome-nba-data-api` | Active serving boundary and initial home for governed batch jobs | Scraper in the request path or training cluster |
+| `awesome-nba-data-api` | Archived historical API scaffold | Runtime dependency or revived standalone API |
+| `nba-lab` | Private fixture-backed product, contracts, and bounded batch layer | Public API or unapproved live acquisition |
 | `nba-task-queue` | Superseded design record; archive candidate | Deployed broker/worker platform without a job contract |
 
-Keep the first production batch jobs in this repository, as a separate package and deployment
-command, until their release cadence or ownership genuinely diverges. A repository boundary is an
-operational commitment, not a substitute for a Python module boundary.
+Keep bounded fixture jobs with NBA Lab. A repository boundary is an operational commitment, not a
+substitute for a Python module boundary.
 
 ## Target data flow
 


### PR DESCRIPTION
## Summary
- mark the placeholder Flask/Connexion service as archived
- link the maintained catalog and private NBA Lab replacement
- preserve history and record the dependency/deployment safety review

No code, migrations, or history are deleted.